### PR TITLE
Surface context errors and raise habr feed timeout to 60s

### DIFF
--- a/backend/internal/application/services/updater/updater.go
+++ b/backend/internal/application/services/updater/updater.go
@@ -36,10 +36,10 @@ func NewService(updater feedUpdater, log *slog.Logger) *Service {
 	return &Service{updater: updater, log: log}
 }
 
-// UpdateAllFeeds refreshes every Habr feed sequentially, isolating each: a real
-// failure or panic is logged and collected but never aborts the rest, and
-// cancellation is suppressed. It returns the joined per-feed failures, or nil if
-// none occurred.
+// UpdateAllFeeds refreshes every Habr feed sequentially, isolating each: a
+// failure or panic — including a cut-short update on shutdown or the cycle's
+// deadline — is logged and collected but never aborts the rest. It returns the
+// joined per-feed failures, or nil if none occurred.
 func (s *Service) UpdateAllFeeds(ctx context.Context) error {
 	var errs []error
 
@@ -48,7 +48,7 @@ func (s *Service) UpdateAllFeeds(ctx context.Context) error {
 			break // shutdown or the cycle's deadline: stop starting new feeds
 		}
 
-		if err := s.updateFeed(ctx, f); err != nil && !isCancellation(err) {
+		if err := s.updateFeed(ctx, f); err != nil {
 			s.log.Error("updater: feed failed", "feed", f.Name(), "err", err)
 			errs = append(errs, fmt.Errorf("%s: %w", f.Name(), err))
 		}
@@ -69,10 +69,4 @@ func (s *Service) updateFeed(ctx context.Context, f habr.RSSFeed) (err error) {
 	}()
 
 	return s.updater.Execute(ctx, f)
-}
-
-// isCancellation reports whether err is context cancellation — shutdown or a
-// cycle's deadline — which is expected and so suppressed from the logs.
-func isCancellation(err error) bool {
-	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
 }

--- a/backend/internal/application/services/updater/updater_test.go
+++ b/backend/internal/application/services/updater/updater_test.go
@@ -57,31 +57,26 @@ func TestUpdateAllFeeds_RunsEveryFeed(t *testing.T) {
 }
 
 // TestUpdateAllFeeds_HandlesEachFeedIndependently pins how one feed's outcome is
-// handled: a real failure or panic is reported in the joined error, a context
-// cancellation is suppressed as expected teardown, and in every case the remaining
-// feeds are still attempted.
+// handled: any failure or panic — a context cancellation included — is reported
+// in the joined error, and in every case the remaining feeds are still attempted.
 func TestUpdateAllFeeds_HandlesEachFeedIndependently(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
-		name         string
-		upd          *fakeFeedUpdater
-		wantReported bool // the offending feed appears in the returned error
+		name string
+		upd  *fakeFeedUpdater
 	}{
 		{
-			name:         "error_is_reported",
-			upd:          &fakeFeedUpdater{errFeed: map[habr.RSSFeed]error{habr.FeedWeekly: errors.New("feed down")}},
-			wantReported: true,
+			name: "error_is_reported",
+			upd:  &fakeFeedUpdater{errFeed: map[habr.RSSFeed]error{habr.FeedWeekly: errors.New("feed down")}},
 		},
 		{
-			name:         "panic_is_recovered_and_reported",
-			upd:          &fakeFeedUpdater{panicFeed: map[habr.RSSFeed]bool{habr.FeedWeekly: true}},
-			wantReported: true,
+			name: "panic_is_recovered_and_reported",
+			upd:  &fakeFeedUpdater{panicFeed: map[habr.RSSFeed]bool{habr.FeedWeekly: true}},
 		},
 		{
-			name:         "cancellation_is_suppressed",
-			upd:          &fakeFeedUpdater{errFeed: map[habr.RSSFeed]error{habr.FeedWeekly: context.Canceled}},
-			wantReported: false,
+			name: "cancellation_is_reported",
+			upd:  &fakeFeedUpdater{errFeed: map[habr.RSSFeed]error{habr.FeedWeekly: context.Canceled}},
 		},
 	}
 
@@ -91,13 +86,11 @@ func TestUpdateAllFeeds_HandlesEachFeedIndependently(t *testing.T) {
 
 			s := NewService(tc.upd, quietLogger())
 
-			err := s.UpdateAllFeeds(context.Background()) // a panicking feed must not crash the run
-			if tc.wantReported {
-				if err == nil || !strings.Contains(err.Error(), habr.FeedWeekly.Name()) {
-					t.Fatalf("error = %v, want it to mention feed %q", err, habr.FeedWeekly.Name())
-				}
-			} else if err != nil {
-				t.Fatalf("error = %v, want nil (cancellation suppressed)", err)
+			// A panicking feed must not crash the run; the offending feed must
+			// appear in the joined error.
+			err := s.UpdateAllFeeds(context.Background())
+			if err == nil || !strings.Contains(err.Error(), habr.FeedWeekly.Name()) {
+				t.Fatalf("error = %v, want it to mention feed %q", err, habr.FeedWeekly.Name())
 			}
 			// The offending feed never aborts the batch: every feed is still attempted.
 			if got, want := tc.upd.calls, habr.AllFeeds(); !reflect.DeepEqual(got, want) {
@@ -117,7 +110,7 @@ func TestUpdateAllFeeds_StopsOnCancellation(t *testing.T) {
 	cancel() // canceled before the loop starts
 
 	if err := s.UpdateAllFeeds(ctx); err != nil {
-		t.Fatalf("UpdateAllFeeds: want nil (cancellation suppressed), got %v", err)
+		t.Fatalf("UpdateAllFeeds: want nil (no feeds attempted), got %v", err)
 	}
 	if got := upd.calls; len(got) != 0 {
 		t.Fatalf("feeds updated = %v, want none (ctx already canceled)", got)

--- a/backend/internal/application/usecases/get_feeds.go
+++ b/backend/internal/application/usecases/get_feeds.go
@@ -74,9 +74,7 @@ func (u *GetFeedsUsecase) Execute(ctx context.Context) ([]*domain.Feed, error) {
 			return nil, fmt.Errorf("getting feeds: %w", err)
 		}
 		// Freshness is not extended, so the next call retries the reload.
-		if !isCancellation(err) {
-			u.log.Error("getting feeds failed; serving stale cache", "err", err)
-		}
+		u.log.Error("getting feeds failed; serving stale cache", "err", err)
 		return u.cache, nil
 	}
 

--- a/backend/internal/application/usecases/update_feed.go
+++ b/backend/internal/application/usecases/update_feed.go
@@ -116,9 +116,8 @@ func articleIDs(arts []*domain.Article) []string {
 // summarizeArticles summarizes the given articles concurrently (one goroutine
 // per article) and returns the ones to persist — those that got a real
 // summary or the placeholder, each with its Summary set. An article whose
-// summary fails for a real reason is logged (with its URL) and dropped;
-// cancellation is suppressed. A panic skips only that article. Every spawned
-// goroutine is joined before returning, so none leaks.
+// summary fails is logged (with its URL) and dropped. A panic skips only that
+// article. Every spawned goroutine is joined before returning, so none leaks.
 func (u *UpdateFeedUsecase) summarizeArticles(ctx context.Context, articles []*domain.Article) []*domain.Article {
 	if len(articles) == 0 {
 		return nil
@@ -141,9 +140,7 @@ func (u *UpdateFeedUsecase) summarizeArticles(ctx context.Context, articles []*d
 
 			summary, err := u.summarize(ctx, a)
 			if err != nil {
-				if !isCancellation(err) {
-					u.log.Error("updating feed: summary failed; skipping article", "url", a.ID, "err", err)
-				}
+				u.log.Error("updating feed: summary failed; skipping article", "url", a.ID, "err", err)
 				return // skip this article; never abort the batch
 			}
 
@@ -182,11 +179,4 @@ func (u *UpdateFeedUsecase) summarize(ctx context.Context, a *domain.Article) (*
 	}
 
 	return summary, nil
-}
-
-// isCancellation reports whether err is context cancellation — the run's
-// deadline or a shutdown. Such errors are expected, not failures, so a canceled
-// per-article summary is suppressed from the logs.
-func isCancellation(err error) bool {
-	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
 }

--- a/backend/internal/infrastructure/habr/client.go
+++ b/backend/internal/infrastructure/habr/client.go
@@ -10,7 +10,7 @@ import (
 	"time"
 )
 
-const defaultTimeout = 10 * time.Second
+const defaultTimeout = 60 * time.Second
 const maxErrSnippet = 2048      // 2KiB
 const maxBodySize = 1024 * 1024 // 1 MiB — top feeds run ~110 KiB (40 items); ~10x headroom
 
@@ -22,7 +22,7 @@ type Client struct {
 }
 
 // NewClient returns a Client backed by hc. If hc is nil, a default
-// [http.Client] with a 10-second timeout is used. A Client must be created
+// [http.Client] with a 60-second timeout is used. A Client must be created
 // with NewClient; the zero value is not usable.
 func NewClient(hc *http.Client) *Client {
 	if hc == nil {


### PR DESCRIPTION
   1 - Drop `isCancellation` so context cancellation/deadline errors are logged and reported like any other failure instead of being silenced (updater, update-feed and get-feeds use cases, with tests adjusted).
   2 - Raise the habr client's default HTTP timeout from 10s to 60s, matching the yagpt client's default.